### PR TITLE
Track upstream Google consent 500s behind removed OAuth flow

### DIFF
--- a/src/yt_study/core/youtube/metadata.py
+++ b/src/yt_study/core/youtube/metadata.py
@@ -246,6 +246,15 @@ def _raise_from_public_access_text(error_text: str, cause: Exception) -> None:
     """Raise a user-facing access error when the text indicates restricted access."""
     normalized_text = error_text.lower()
 
+    # Detect Google OAuth consent 500 errors (upstream issue)
+    # See: https://github.com/whoisjayd/yt-study/issues/55
+    if _is_google_consent_500_error(normalized_text):
+        raise PublicAccessRequiredError(
+            "This video requires sign-in access, but OAuth support has been removed "
+            "due to upstream Google consent flow failures (500 Internal Server Error). "
+            "Use a public or unlisted video instead."
+        ) from cause
+
     if (
         "private video" in normalized_text
         or "this is a private video" in normalized_text
@@ -273,3 +282,35 @@ def _raise_from_public_access_text(error_text: str, cause: Exception) -> None:
             "Sign-in-only YouTube videos are not supported. "
             "Use a public or unlisted video to process it."
         ) from cause
+
+
+def _is_google_consent_500_error(error_text: str) -> bool:
+    """Detect Google OAuth consent 500 errors from upstream.
+
+    Google device-flow consent screen fails with 500 errors before token issuance
+    completes, making OAuth unreliable. This detects error messages indicating
+    that specific failure mode.
+
+    See: https://github.com/whoisjayd/yt-study/issues/55
+    """
+    # Core indicators of the consent 500 issue
+    has_500 = "500" in error_text or "internal server error" in error_text
+    has_consent = "consent" in error_text
+    has_oauth = "oauth" in error_text or "oauth" in error_text
+
+    # Combined patterns that indicate the specific Google consent failure
+    if has_500 and (has_consent or has_oauth):
+        return True
+
+    # Specific error patterns observed in the wild
+    consent_patterns = [
+        "consent/approval",
+        "oauth/consent",
+        "accounts.google.com/signin/oauth",
+        "device flow",
+    ]
+    for pattern in consent_patterns:
+        if pattern in error_text and has_500:
+            return True
+
+    return False

--- a/src/yt_study/core/youtube/transcript.py
+++ b/src/yt_study/core/youtube/transcript.py
@@ -83,6 +83,15 @@ def _raise_if_public_access_required(error: Exception) -> None:
         sub_reasons = " ".join(getattr(error, "sub_reasons", []) or []).lower()
         error_text = f"{reason} {sub_reasons} {error_text}"
 
+    # Detect Google OAuth consent 500 errors (upstream issue)
+    # See: https://github.com/whoisjayd/yt-study/issues/55
+    if _is_google_consent_500_error(error_text):
+        raise PublicAccessRequiredError(
+            "This video requires sign-in access, but OAuth support has been removed "
+            "due to upstream Google consent flow failures (500 Internal Server Error). "
+            "Use a public or unlisted video instead."
+        ) from error
+
     if "private" in error_text:
         raise PublicAccessRequiredError(
             "Private YouTube videos are not supported. "
@@ -112,6 +121,38 @@ def _raise_if_public_access_required(error: Exception) -> None:
             "Sign-in-only YouTube videos are not supported. "
             "Use a public or unlisted video to process it."
         ) from error
+
+
+def _is_google_consent_500_error(error_text: str) -> bool:
+    """Detect Google OAuth consent 500 errors from upstream.
+
+    Google device-flow consent screen fails with 500 errors before token issuance
+    completes, making OAuth unreliable. This detects error messages indicating
+    that specific failure mode.
+
+    See: https://github.com/whoisjayd/yt-study/issues/55
+    """
+    # Core indicators of the consent 500 issue
+    has_500 = "500" in error_text or "internal server error" in error_text
+    has_consent = "consent" in error_text
+    has_oauth = "oauth" in error_text or "oauth" in error_text
+
+    # Combined patterns that indicate the specific Google consent failure
+    if has_500 and (has_consent or has_oauth):
+        return True
+
+    # Specific error patterns observed in the wild
+    consent_patterns = [
+        "consent/approval",
+        "oauth/consent",
+        "accounts.google.com/signin/oauth",
+        "device flow",
+    ]
+    for pattern in consent_patterns:
+        if pattern in error_text and has_500:
+            return True
+
+    return False
 
 
 def _describe_video_unplayable(error: VideoUnplayable) -> str:


### PR DESCRIPTION
## Summary

This PR adds detection for Google OAuth consent 500 errors that occur when attempting to authenticate via the device-flow OAuth path. This addresses issue #55 where the Google consent screen fails with 500 Internal Server Error before token issuance completes.

## Changes

- Added `_is_google_consent_500_error()` helper function to detect error patterns indicating the upstream Google consent flow failure
- Updated error handling in both `metadata.py` and `transcript.py` to catch these specific errors
- Provides a user-friendly error message explaining that OAuth support has been removed due to upstream issues and suggesting public/unlisted videos instead

## Error Detection Patterns

The following patterns are detected as Google consent 500 errors:
- `500` + `consent` or `oauth` in error text
- `consent/approval` endpoint with 500 errors
- `accounts.google.com/signin/oauth` with 500 errors
- `device flow` with 500 errors

## Testing

- All existing tests pass (69 tests in test_youtube/)
- Manual verification of the consent 500 error detection function

## References

Fixes #55

## Summary by Sourcery

Handle upstream Google OAuth consent 500 errors as unsupported sign-in-only access and guide users to public/unlisted videos instead.

Bug Fixes:
- Detect Google OAuth consent 500 errors during metadata and transcript fetches and surface them as a clear, user-facing access limitation instead of a generic failure.

Enhancements:
- Introduce a shared helper to identify Google device-flow consent 500 error patterns based on HTTP status and known OAuth/consent endpoints.