### PR TITLE
Add --stitch CLI flag for chunk stitching pipeline

### DIFF
--- a/src/notewise/cli/_context.py
+++ b/src/notewise/cli/_context.py
@@ -34,6 +34,7 @@ class CliProcessContext:
     selected_max_tokens: int | None
     force: bool
     no_ui: bool
+    stitch: bool
     quiz: bool
     export_transcript: str | None
     selected_cookie_file: str | None
@@ -116,6 +117,7 @@ class CliProcessContext:
             temperature=self.selected_temperature,
             max_tokens=self.selected_max_tokens,
             force=self.force,
+            stitch=self.stitch,
             quiz=self.quiz,
             export_transcript=self.export_transcript,
             youtube_cookie_file=self.selected_cookie_file,

--- a/src/notewise/cli/app.py
+++ b/src/notewise/cli/app.py
@@ -211,7 +211,15 @@ def process(
             ),
             show_default=False,
         ),
+        
     ],
+    stitch: Annotated[
+    bool,
+    typer.Option(
+        "--stitch",
+        help="Enable stitching of chunked outputs before final result.",
+    ),
+] = False,
     model: Annotated[
         str | None,
         typer.Option(
@@ -351,6 +359,8 @@ def process(
 
         configure_logging()
         settings = _get_config()
+        if stitch:
+            console.print("[yellow]Stitching enabled (WIP)[/yellow]")
 
         runner = CliProcessRunner(
             console=console,

--- a/src/notewise/cli/app.py
+++ b/src/notewise/cli/app.py
@@ -211,15 +211,14 @@ def process(
             ),
             show_default=False,
         ),
-        
     ],
     stitch: Annotated[
-    bool,
-    typer.Option(
-        "--stitch",
-        help="Enable stitching of chunked outputs before final result.",
-    ),
-] = False,
+        bool,
+        typer.Option(
+            "--stitch",
+            help="{experimental}Enable stitching of chunked outputs before final result.",
+        ),
+    ] = False,
     model: Annotated[
         str | None,
         typer.Option(
@@ -359,8 +358,6 @@ def process(
 
         configure_logging()
         settings = _get_config()
-        if stitch:
-            console.print("[yellow]Stitching enabled (WIP)[/yellow]")
 
         runner = CliProcessRunner(
             console=console,
@@ -382,6 +379,7 @@ def process(
             ),
             force=force,
             no_ui=no_ui,
+            stitch=stitch,
             quiz=quiz,
             export_transcript=export_transcript,
             selected_cookie_file=(


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I ran `make ci` locally and all checks passed (`format-check`, `lint-check`, `type-check`, `deps-check`, `security`, `test-cov`).
- [ ] I added or updated tests for the behavior change.
- [ ] I updated docs for user-facing changes.
- [ ] I documented any breaking change in this PR description.

## Validation Commands

```bash
make ci
```

Optional local quality commands:

```bash
make check
make verify
make pre-commit
```

## Summary
This PR adds initial support for the --stitch CLI flag to the process command.

Introduced a new --stitch option
Added a placeholder console message when stitching is enabled

Validation performed locally:
Confirmed it triggers expected console message during execution

This sets up the CLI interface for future integration of stitching logic.


## Related Issue

Closes #67 

## Summary by Sourcery

New Features:
- Introduce a --stitch boolean CLI option to control whether chunked outputs are stitched before producing the final result.