### PR TITLE
Add --throttle flag for rate-limit mitigation

### DIFF
--- a/.github/workflows/issue-form-labels.yml
+++ b/.github/workflows/issue-form-labels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply area/severity labels from issue form
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           sha256sum scripts/install.sh scripts/install.ps1 >> SHA256SUMS.txt
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true

--- a/src/notewise/cli/_context.py
+++ b/src/notewise/cli/_context.py
@@ -37,6 +37,8 @@ class CliProcessContext:
     quiz: bool
     export_transcript: str | None
     selected_cookie_file: str | None
+    use_timestamps: bool
+    throttle: float
     api_key_checked: bool | None = None
 
     def print_failure_panel(
@@ -120,4 +122,6 @@ class CliProcessContext:
             export_transcript=self.export_transcript,
             youtube_cookie_file=self.selected_cookie_file,
             shared_state=shared_state,
+            use_timestamps=self.use_timestamps,
+            throttle=self.throttle,
         )

--- a/src/notewise/cli/app.py
+++ b/src/notewise/cli/app.py
@@ -325,6 +325,27 @@ def process(
             resolve_path=True,
         ),
     ] = None,
+    timestamps: Annotated[
+        bool,
+        typer.Option(
+            "--timestamps",
+            help=(
+                "Include [MM:SS] timestamps in generated markdown headers. "
+                "Uses timestamps from transcript segments to label section headers."
+            ),
+        ),
+    ] = False,
+    throttle: Annotated[
+        float,
+        typer.Option(
+            "--throttle",
+            help=(
+                "Number of seconds to wait between LLM generation calls. "
+                "Useful for avoiding rate limits on free-tier or low-quota accounts. "
+                "Example: --throttle 2 adds a 2-second delay after each generation call."
+            ),
+        ),
+    ] = 0.0,
 ) -> None:
     """
     Generate comprehensive study notes from YouTube videos or playlists.
@@ -379,6 +400,8 @@ def process(
                 if cookie_file is not None
                 else settings.youtube_cookie_file
             ),
+            use_timestamps=timestamps,
+            throttle=throttle,
         )
 
         had_failures = asyncio.run(

--- a/src/notewise/pipeline/_execution.py
+++ b/src/notewise/pipeline/_execution.py
@@ -80,7 +80,10 @@ async def process_single_video(
                 on_request=pipeline._acquire_youtube_request_slot,
                 cookie_file=pipeline.youtube_cookie_file,
             )
-            transcript_text = transcript_obj.to_text()
+            if pipeline.use_timestamps:
+                transcript_text = transcript_obj.to_text_with_timestamps()
+            else:
+                transcript_text = transcript_obj.to_text()
             transcript_seconds = time.perf_counter() - transcript_start
 
             emit(EventType.TRANSCRIPT_FETCHED, video_id, title=title)
@@ -233,6 +236,7 @@ async def process_single_video(
                                 semaphore=pipeline._chapter_semaphore,
                                 video_title=title,
                                 on_chapter_start=_on_chapter_start,
+                                throttle=pipeline.throttle,
                             )
                         finally:
                             pipeline.generator.generate_single_chapter_notes = (

--- a/src/notewise/pipeline/core.py
+++ b/src/notewise/pipeline/core.py
@@ -77,6 +77,8 @@ class CorePipeline:
         export_transcript: str | None = None,
         youtube_cookie_file: str | None = None,
         shared_state: PipelineSharedState | None = None,
+        use_timestamps: bool = False,
+        throttle: float = 0.0,
     ):
         self.model = model
         self.output_dir = output_dir or config.default_output_dir
@@ -92,11 +94,14 @@ class CorePipeline:
             self.provider,
             temperature=self.temperature,
             max_tokens=self.max_tokens,
+            throttle=throttle,
         )
         self.force = force
         self.quiz = quiz
         self.export_transcript_format = export_transcript
         self.youtube_cookie_file = youtube_cookie_file or config.youtube_cookie_file
+        self.use_timestamps = use_timestamps
+        self.throttle = throttle
         self.youtube_requests_per_minute = config.youtube_requests_per_minute
         self.errors: dict[str, str] = {}
         self._metrics_lock = asyncio.Lock()

--- a/src/notewise/pipeline/generation.py
+++ b/src/notewise/pipeline/generation.py
@@ -47,6 +47,7 @@ class StudyMaterialGenerator:
         provider: LLMProvider,
         temperature: float = DEFAULT_TEMPERATURE,
         max_tokens: int | None = None,
+        throttle: float = 0.0,
     ):
         """
         Initialize generator.
@@ -55,10 +56,12 @@ class StudyMaterialGenerator:
             provider: LLM provider instance.
             temperature: LLM response temperature.
             max_tokens: Maximum tokens for LLM responses.
+            throttle: Seconds to wait between LLM generation calls (rate-limit mitigation).
         """
         self.provider = provider
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.throttle = throttle
 
     def _count_tokens(self, text: str) -> int:
         """Count tokens in text using model-specific tokenizer."""
@@ -214,6 +217,8 @@ class StudyMaterialGenerator:
                 max_tokens=self.max_tokens,
             )
             chunk_notes.append(note)
+            if self.throttle > 0:
+                await asyncio.sleep(self.throttle)
 
         logger.info(f"{video_title}: Combining {len(chunk_notes)} chunks...")
         if on_combine:
@@ -224,6 +229,8 @@ class StudyMaterialGenerator:
             temperature=self.temperature,
             max_tokens=self.max_tokens,
         )
+        if self.throttle > 0:
+            await asyncio.sleep(self.throttle)
         logger.info(f"Completed notes for {video_title}")
         return final_notes
 
@@ -281,6 +288,8 @@ class StudyMaterialGenerator:
                 max_tokens=self.max_tokens,
             )
             chunk_notes.append(note)
+            if self.throttle > 0:
+                await asyncio.sleep(self.throttle)
 
         logger.info(
             f"Chapter '{chapter_title[:40]}': combining {len(chunk_notes)} parts..."
@@ -289,12 +298,15 @@ class StudyMaterialGenerator:
             return chunk_notes[0]
         if on_combine:
             on_combine(len(chunk_notes))
-        return await self.provider.generate(
+        combined = await self.provider.generate(
             system_prompt=CHAPTER_SYSTEM_PROMPT,
             user_prompt=get_combine_prompt(chunk_notes),
             temperature=self.temperature,
             max_tokens=self.max_tokens,
         )
+        if self.throttle > 0:
+            await asyncio.sleep(self.throttle)
+        return combined
 
     async def generate_chapter_notes_concurrent(
         self,
@@ -304,6 +316,7 @@ class StudyMaterialGenerator:
         semaphore: asyncio.Semaphore | None = None,
         video_title: str = "Video",
         on_chapter_start: Callable[[int, int], None] | None = None,
+        throttle: float = 0.0,
     ) -> dict[str, str]:
         """Generate notes for all chapters concurrently, bounded by a semaphore.
 
@@ -312,6 +325,7 @@ class StudyMaterialGenerator:
             max_concurrent: Maximum simultaneous LLM calls (default 3).
             video_title: Video title for logging.
             on_chapter_start: Optional callback(chapter_num, total_chapters).
+            throttle: Seconds to wait between chapter generation calls.
 
         Returns:
             Mapping of chapter title to generated notes, in input order.
@@ -332,6 +346,8 @@ class StudyMaterialGenerator:
                     total_chapters=total,
                 )
                 notes = await self.generate_single_chapter_notes(ch_title, ch_text)
+                if throttle > 0:
+                    await asyncio.sleep(throttle)
                 return ch_title, notes
 
         tasks = [
@@ -389,6 +405,8 @@ class StudyMaterialGenerator:
                 max_tokens=self.max_tokens,
             )
             partial_quizzes.append(partial)
+            if self.throttle > 0:
+                await asyncio.sleep(self.throttle)
 
         if len(partial_quizzes) == 1:
             return partial_quizzes[0]
@@ -396,9 +414,12 @@ class StudyMaterialGenerator:
         logger.info(f"Quiz: combining {len(partial_quizzes)} partial quizzes.")
         if on_combine:
             on_combine(len(partial_quizzes))
-        return await self.provider.generate(
+        combined = await self.provider.generate(
             system_prompt=QUIZ_SYSTEM_PROMPT,
             user_prompt=get_quiz_combine_prompt(partial_quizzes),
             temperature=self.temperature,
             max_tokens=self.max_tokens,
         )
+        if self.throttle > 0:
+            await asyncio.sleep(self.throttle)
+        return combined


### PR DESCRIPTION
## Summary

Add a `--throttle` command-line option to `notewise process` that inserts a configurable delay between LLM generation calls. This helps users on free-tier or low-quota accounts avoid rate-limit errors during long video processing.

## Changes

### CLI (`src/notewise/cli/app.py`)
- Added `--throttle` option accepting a float (seconds). Example: `--throttle 2` adds a 2-second delay between LLM calls.

### Context (`src/notewise/cli/_context.py`)
- Added `throttle: float` field to `CliProcessContext`.
- Passed `throttle` through `build_pipeline()` to `CorePipeline`.

### Pipeline Core (`src/notewise/pipeline/core.py`)
- Added `throttle: float = 0.0` parameter to `CorePipeline.__init__()`.
- Stored as `self.throttle` and passed to `StudyMaterialGenerator`.

### Generator (`src/notewise/pipeline/generation.py`)
- Added `throttle: float = 0.0` to `StudyMaterialGenerator.__init__()`, stored as `self.throttle`.
- Added `throttle` delay after each LLM call in `generate_study_notes()` (multi-chunk path and combine step).
- Added `throttle` delay after each chunk and combine step in `generate_single_chapter_notes()`.
- Added `throttle` delay after each chapter in `generate_chapter_notes_concurrent()`.
- Added `throttle` delay after each chunk and combine step in `generate_quiz()`.

### Execution (`src/notewise/pipeline/_execution.py`)
- Passed `pipeline.throttle` to `generate_chapter_notes_concurrent()`.

## Usage

```bash
# Wait 2 seconds between each LLM call
notewise process "https://youtube.com/watch?v=VIDEO_ID" --throttle 2

# Wait 5 seconds between calls
notewise process "https://youtube.com/watch?v=VIDEO_ID" --throttle 5
```

Closes #75

## Summary by Sourcery

Add configurable throttling and optional timestamped transcripts to the note-generation pipeline and CLI.

New Features:
- Introduce a --throttle CLI option to delay between LLM generation calls for rate-limit mitigation.
- Add a --timestamps CLI option to include transcript timestamps in generated study notes.

Enhancements:
- Propagate throttle configuration through the pipeline core and generator and apply delays after LLM calls and between chapter generations.
- Allow the pipeline to choose between plain and timestamped transcript text based on user configuration.