### PR TITLE
build(deps): bump litellm in the python-dependencies group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "litellm==1.83.3",
+    "litellm==1.83.10",
     "typer>=0.21.1",
     "rich>=13.9.4",
     "aiolimiter>=1.2.1",


### PR DESCRIPTION
Bumps the python-dependencies group with 1 update: [litellm](https://github.com/BerriAI/litellm).


Updates `litellm` from 1.83.3 to 1.83.10
- [Release notes](https://github.com/BerriAI/litellm/releases)
- [Commits](https://github.com/BerriAI/litellm/commits)

---
updated-dependencies:
- dependency-name: litellm dependency-version: 1.83.10 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-dependencies ...