### PR TITLE
fix: sanitize dangerous URL schemes in HTML export (fixes #107)

### DIFF
--- a/src/notewise/pipeline/_documents.py
+++ b/src/notewise/pipeline/_documents.py
@@ -176,6 +176,54 @@ def _normalize_markdown_blocks(markdown_text: str) -> str:
     return "\n".join(normalized_lines)
 
 
+# Dangerous URL schemes that should never appear in href/src attributes.
+_DANGEROUS_URL_SCHEME_RE = re.compile(
+    r"""(?xi)
+    (
+        javascript
+        | vbscript
+        | data
+    )\s*:"""
+)
+
+
+def _sanitize_html_links(html: str) -> str:
+    """Strip dangerous URL schemes from href and src attributes.
+
+    Runs *after* Markdown-to-HTML conversion so that schemes embedded in
+    Markdown link/image syntax (e.g. ``[click](javascript:alert(1))``) are
+    also caught.
+
+    Safe schemes (``http``, ``https``, ``mailto``, ``ftp``, relative paths)
+    are preserved as-is.
+    """
+
+    def _neutralize(match: re.Match[str]) -> str:
+        attr, quote, value, end_quote = (
+            match.group(1),
+            match.group(2),
+            match.group(3),
+            match.group(4),
+        )
+        if _DANGEROUS_URL_SCHEME_RE.match(value.lstrip()):
+            # Replace the entire attribute value with an empty string so the
+            # element remains in place but the link is inert.
+            return f"{attr}={quote}{end_quote}"
+        return match.group(0)
+
+    # Match href="..." / href='...' / src="..." / src='...' (case-insensitive).
+    _ATTR_RE = re.compile(
+        r"""(?xi)
+        (href|src)          # group 1: attribute name
+        \s*=\s*
+        ([\"'])             # group 2: opening quote
+        ([^\"']*)           # group 3: attribute value
+        ([\"'])             # group 4: closing quote
+        """
+    )
+    return _ATTR_RE.sub(_neutralize, html)
+
+
 def _markdown_to_html(markdown_text: str) -> str:
     import markdown as markdown_lib
 
@@ -184,7 +232,8 @@ def _markdown_to_html(markdown_text: str) -> str:
         safe_markdown,
         extensions=list(MARKDOWN_RENDER_EXTENSIONS),
     )
-    return _normalize_rendered_html(rendered_html)
+    sanitized_html = _sanitize_html_links(rendered_html)
+    return _normalize_rendered_html(sanitized_html)
 
 
 def _escape_raw_html(markdown_text: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #107 — HTML export was rendering Markdown links like `[click](javascript:alert(1))` into live `<a href="javascript:...">` elements without any URL-scheme validation.

## Root Cause

`_markdown_to_html()` ran `_escape_raw_html()` on the *input* Markdown before conversion, but never sanitized the *output* HTML after `markdown_lib.markdown()` rendered it. A `javascript:` scheme is not raw HTML before conversion, so the existing escaping layer never neutralized it.

## Fix

Added `_sanitize_html_links()`, called inside `_markdown_to_html()` **after** Markdown conversion:

```python
def _sanitize_html_links(html: str) -> str:
    """Strip dangerous URL schemes from href and src attributes."""
    ...
```

The function strips the `href`/`src` value (leaving the element intact but inert) when the URL begins with:

- `javascript:` (and mixed-case variants like `JaVaScRiPt:`)
- `vbscript:`
- `data:`

Safe schemes (`http`, `https`, `mailto`, relative paths) pass through unchanged.

## Verification

```python
_sanitize_html_links('<a href="javascript:alert(1)">x</a>')
# → '<a href="">x</a>'

_sanitize_html_links('<a href="JaVaScRiPt:alert(1)">x</a>')
# → '<a href="">x</a>'

_sanitize_html_links('<a href="https://example.com">safe</a>')
# → '<a href="https://example.com">safe</a>'  (unchanged)
```

## Acceptance Criteria (from issue)

- [x] `[x](javascript:alert(1))` does not render an active `javascript:` href
- [x] Mixed-case variants like `[x](JaVaScRiPt:alert(1))` are neutralized
- [x] `data:` URLs in links/images are stripped
- [x] Normal safe links like `[x](https://example.com)` still render correctly

## Summary by Sourcery

Bug Fixes:
- Strip dangerous URL schemes such as javascript:, vbscript:, and data: from href and src attributes in exported HTML while preserving otherwise safe URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content security by implementing HTML sanitization. Dangerous URL schemes (JavaScript, VBScript, and data: URLs) in links and embedded resources are now neutralized during Markdown conversion, protecting documents from potential security vulnerabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whoisjayd/notewise/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->