### PR TITLE
fix(ui): guard setup wizard when model catalog is empty

### DIFF
--- a/src/notewise/_constants.py
+++ b/src/notewise/_constants.py
@@ -295,6 +295,12 @@ OAUTH_LOGIN_UNSUPPORTED_PROVIDER_MESSAGE = (
 )
 OAUTH_UNSUPPORTED_PROVIDER_ERROR = "Unsupported OAuth provider: {provider}."
 OAUTH_SETUP_RUN_PROMPT = "Run OAuth login now?"
+SETUP_EMPTY_MODEL_CATALOG_MESSAGE = (
+    "No setup-safe model catalog is available right now."
+)
+SETUP_EMPTY_MODEL_CATALOG_RETRY_MESSAGE = (
+    "Reinstall notewise or retry with network access, then run setup again."
+)
 OAUTH_FALLBACK_MESSAGE = (
     "OAuth login failed or was cancelled. "
     "Run `notewise auth login` for your provider and try again."

--- a/src/notewise/ui/setup_wizard.py
+++ b/src/notewise/ui/setup_wizard.py
@@ -460,6 +460,15 @@ def run_setup_wizard(
 
     active_console.print("\n[cyan]Loading available models...[/cyan]")
     available_models = get_available_models(console=active_console)
+    if not available_models:
+        active_console.print(
+            "[red]No setup-safe model catalog is available right now.[/red]"
+        )
+        active_console.print(
+            "[yellow]Reinstall notewise or retry with network access, "
+            "then run setup again.[/yellow]"
+        )
+        return current_config
     active_console.print(
         f"[green]✓ Found {sum(len(m) for m in available_models.values())} "
         f"models across {len(available_models)} providers[/green]"

--- a/src/notewise/ui/setup_wizard.py
+++ b/src/notewise/ui/setup_wizard.py
@@ -13,6 +13,8 @@ from notewise._constants import (
     DEFAULT_OUTPUT_DIR,
     OAUTH_SETUP_RUN_PROMPT,
     PROVIDER_CONFIG,
+    SETUP_EMPTY_MODEL_CATALOG_MESSAGE,
+    SETUP_EMPTY_MODEL_CATALOG_RETRY_MESSAGE,
 )
 from notewise._constants import (
     LEGACY_CONFIG_KEYS as APP_LEGACY_CONFIG_KEYS,
@@ -461,12 +463,9 @@ def run_setup_wizard(
     active_console.print("\n[cyan]Loading available models...[/cyan]")
     available_models = get_available_models(console=active_console)
     if not available_models:
+        active_console.print(f"[red]{SETUP_EMPTY_MODEL_CATALOG_MESSAGE}[/red]")
         active_console.print(
-            "[red]No setup-safe model catalog is available right now.[/red]"
-        )
-        active_console.print(
-            "[yellow]Reinstall notewise or retry with network access, "
-            "then run setup again.[/yellow]"
+            f"[yellow]{SETUP_EMPTY_MODEL_CATALOG_RETRY_MESSAGE}[/yellow]"
         )
         return current_config
     active_console.print(

--- a/tests/unit/ui/test_setup_wizard.py
+++ b/tests/unit/ui/test_setup_wizard.py
@@ -607,6 +607,25 @@ class TestWizardOrchestration:
 
             mock_save.assert_called_once()
 
+    def test_run_setup_wizard_stops_when_model_catalog_empty(self):
+        """Wizard should stop before provider prompts when no models are available."""
+        console = MagicMock()
+        current_config = {"DEFAULT_MODEL": "gemini/gemini-pro"}
+
+        with (
+            patch("notewise.ui.setup_wizard.load_config", return_value=current_config),
+            patch("notewise.ui.setup_wizard.get_available_models", return_value={}),
+            patch("notewise.ui.setup_wizard.select_provider") as mock_provider,
+            patch("notewise.ui.setup_wizard.save_config") as mock_save,
+        ):
+            result = run_setup_wizard(force=True, console=console)
+
+        assert result == current_config
+        mock_provider.assert_not_called()
+        mock_save.assert_not_called()
+        rendered = "".join(str(call.args[0]) for call in console.print.call_args_list)
+        assert "No setup-safe model catalog is available right now." in rendered
+
     def test_run_setup_wizard_skips_api_key_for_oauth_provider(self):
         """OAuth/device-flow providers should not prompt for static API keys."""
         with (


### PR DESCRIPTION
## Pull Request Checklist

- [x] I read `CONTRIBUTING.md` and followed the contribution workflow.
- [x] This PR targets `dev` (or is an explicit maintainer-managed release PR targeting `main`).
- [ ] I ran `make ci` locally and all checks passed (`format-check`, `lint-check`, `type-check`, `deps-check`, `security`, `test-cov`).
- [x] I added or updated tests for the behavior change.
- [ ] I updated docs for user-facing changes.
- [ ] I documented any breaking change in this PR description.

## Validation Commands

```bash
uv run pytest tests/unit/ui/test_setup_wizard.py -q
uv run pre-commit run --files src/notewise/ui/setup_wizard.py tests/unit/ui/test_setup_wizard.py
uv run pre-commit run --hook-stage pre-push --files src/notewise/ui/setup_wizard.py tests/unit/ui/test_setup_wizard.py
```

`make` is not available in this Windows environment, so I ran the equivalent pre-commit and test commands directly.

## Summary

Add an early guard in `run_setup_wizard()` for an empty setup model catalog.
When `get_available_models()` returns `{}`, the wizard now prints a recovery message and returns before provider/model prompts or config writes.
Added a unit test to verify `select_provider()` and `save_config()` are not called in this path.

## Related Issue

Closes #108

## Summary by Sourcery

Guard the setup wizard from running when no setup-safe models are available and ensure this behavior is covered by tests.

Bug Fixes:
- Prevent the setup wizard from proceeding when the model catalog is empty, returning the existing configuration and showing recovery guidance instead.

Tests:
- Add a unit test verifying the wizard exits early on an empty model catalog without prompting for a provider or saving config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Setup wizard now validates model availability before proceeding with configuration and displays clear error messages if no models are found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whoisjayd/notewise/pull/117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->