### PR TITLE
fix: add parents=True to mkdir in get_config_path

### DIFF
--- a/src/notewise/ui/setup_wizard.py
+++ b/src/notewise/ui/setup_wizard.py
@@ -75,7 +75,7 @@ def _load_bundled_model_snapshot() -> dict[str, list[str]]:
 def get_config_path() -> Path:
     """Get path to user config file."""
     config_dir = get_state_dir()
-    config_dir.mkdir(exist_ok=True)
+    config_dir.mkdir(exist_ok=True, parents=True)
     return config_dir / CONFIG_FILENAME
 
 


### PR DESCRIPTION
## Summary

Fixes setup failure when `NOTEWISE_HOME` is set to a nested path whose parent directories do not exist.

## Problem

`get_config_path()` in `src/notewise/ui/setup_wizard.py` calls `mkdir(exist_ok=True)` without `parents=True`. This causes `notewise setup` to fail if `NOTEWISE_HOME` points to a path like `/tmp/new/parent/.notewise` where `/tmp/new/parent/` doesn't exist.

Other state/output paths (repository.py, logging.py, pipeline/_documents.py) use `mkdir` with `parents=True`, so setup should be consistent.

## Fix

Change `config_dir.mkdir(exist_ok=True)` to `config_dir.mkdir(exist_ok=True, parents=True)`.

## Test Plan

- [ ] `NOTEWISE_HOME=/tmp/new/parent/.notewise notewise setup` should succeed even when `/tmp/new/parent/` doesn't exist

Fixes #109

## Summary by Sourcery

Bug Fixes:
- Fix failure when creating the config directory if its parent path does not already exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration directory creation during setup to properly handle cases where parent directories do not already exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whoisjayd/notewise/pull/118)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->