### PR TITLE
fix: create parent dirs for nested NOTEWISE_HOME in setup

### DIFF
--- a/src/notewise/ui/setup_wizard.py
+++ b/src/notewise/ui/setup_wizard.py
@@ -75,7 +75,7 @@ def _load_bundled_model_snapshot() -> dict[str, list[str]]:
 def get_config_path() -> Path:
     """Get path to user config file."""
     config_dir = get_state_dir()
-    config_dir.mkdir(exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
     return config_dir / CONFIG_FILENAME
 
 


### PR DESCRIPTION
## Summary

Fix setup wizard config path creation to use `parents=True` when creating the state directory, consistent with repository/log/output initialization patterns.

## Problem

When `NOTEWISE_HOME` points to a nested path whose parent directories don't exist (e.g., `/tmp/new/parent/.notewise`), `notewise setup` fails because `mkdir(exist_ok=True)` doesn't create parent directories.

## Solution

Changed `config_dir.mkdir(exist_ok=True)` to `config_dir.mkdir(parents=True, exist_ok=True)` in `src/notewise/ui/setup_wizard.py:78`.

## Test Plan

- [x] Fix is consistent with existing patterns in repository.py, logging.py, and _documents.py

Closes whoisjayd/notewise#109

## Summary by Sourcery

Bug Fixes:
- Prevent setup from failing when NOTEWISE_HOME points to a nested path whose parent directories do not yet exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the setup wizard could fail when initializing configuration if intermediate system directories were missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whoisjayd/notewise/pull/119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->