### PR TITLE
fix: create parent directories for nested NOTEWISE_HOME config path

### DIFF
--- a/src/notewise/ui/setup_wizard.py
+++ b/src/notewise/ui/setup_wizard.py
@@ -77,7 +77,7 @@ def _load_bundled_model_snapshot() -> dict[str, list[str]]:
 def get_config_path() -> Path:
     """Get path to user config file."""
     config_dir = get_state_dir()
-    config_dir.mkdir(exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
     return config_dir / CONFIG_FILENAME
 
 

--- a/tests/unit/ui/test_setup_wizard.py
+++ b/tests/unit/ui/test_setup_wizard.py
@@ -96,6 +96,31 @@ class TestConfigIO:
         with pytest.raises(RuntimeError, match="bug"):
             load_config()
 
+    def test_get_config_path_creates_nested_notewise_home(self, monkeypatch, tmp_path):
+        """Setup should create all parent directories for a nested NOTEWISE_HOME."""
+        nested_path = tmp_path / "new" / "parent" / ".notewise"
+        monkeypatch.setenv("NOTEWISE_HOME", str(nested_path))
+
+        # Directory chain does not exist yet
+        assert not nested_path.exists()
+
+        config_path = get_config_path()
+
+        # All parents and the leaf config directory should be created
+        assert nested_path.is_dir()
+        assert config_path.parent == nested_path
+        assert config_path.name == "config.env"
+
+    def test_get_config_path_works_with_existing_dir(self, monkeypatch, tmp_path):
+        """Should not fail when NOTEWISE_HOME already exists."""
+        existing = tmp_path / "existing" / ".notewise"
+        existing.mkdir(parents=True)
+        monkeypatch.setenv("NOTEWISE_HOME", str(existing))
+
+        config_path = get_config_path()
+        assert config_path.parent == existing
+        assert config_path.name == "config.env"
+
     def test_save_config(self):
         """Test saving configuration merges with existing."""
         from pathlib import Path


### PR DESCRIPTION
## Summary

Fixes #109

When `NOTEWISE_HOME` points to a nested path whose parents do not exist, `notewise setup` fails before writing config because `get_config_path()` only calls `mkdir(exist_ok=True)` without `parents=True`.

## Root Cause

`get_config_path()` in `src/notewise/ui/setup_wizard.py:78` creates the state directory with `config_dir.mkdir(exist_ok=True)`, which raises `FileNotFoundError` when intermediate parent directories are missing. Other state/output code paths (repository.py, logging.py, _documents.py) already use `parents=True`, creating an inconsistency.

## Fix

Changed `config_dir.mkdir(exist_ok=True)` to `config_dir.mkdir(parents=True, exist_ok=True)`, matching the existing parent-safe creation pattern used by:
- `src/notewise/storage/repository.py:40`
- `src/notewise/logging.py:256`
- `src/notewise/pipeline/_documents.py:119`

## Changes

- `src/notewise/ui/setup_wizard.py`: 1 line changed (`+1 -1`)
- `tests/unit/ui/test_setup_wizard.py`: 2 test cases added (`+25 -0`)

## Testing

- **Nested NOTEWISE_HOME with missing parents**: Directory chain created successfully, config path returned ✅
- **Existing NOTEWISE_HOME directory**: No error, config path returned correctly ✅
- **All 36 existing setup_wizard tests**: No regressions ✅

## Summary by Sourcery

Ensure setup wizard creates configuration directories safely when NOTEWISE_HOME points to nested paths.

Bug Fixes:
- Fix failure when NOTEWISE_HOME points to a nested path whose parent directories do not exist by creating all missing parents before writing config.

Tests:
- Add tests verifying get_config_path creates nested NOTEWISE_HOME directories and works when the config directory already exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced setup wizard to properly create parent directories when initializing the configuration directory structure, ensuring the setup process works correctly for all directory path scenarios.

* **Tests**
  * Added unit tests validating configuration directory creation with both existing and non-existent directory paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whoisjayd/notewise/pull/120)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->